### PR TITLE
Fix nodrop using std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ keywords = ["abstraction", "initialization", "no_std"]
 [features]
 nightly = ["nodrop/use_union"]
 
-[dependencies]
-nodrop = "0.1.9"
+[dependencies.nodrop]
+version = "0.1.12"
+default-features = false


### PR DESCRIPTION
This PR disables the default features on `nodrop` to stop it from using `std`. Currently, `array-init`, itself is `no_std`, but `nodrop` isn't, which makes it unusable for `no_std` crates. This PR also updates `nodrop` to its latest version.