### PR TITLE
Fixed array_init() / from_iter() memory_leak on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
 name = "array-init"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
+edition = "2018"
 description = "Safe wrapper for initializing fixed-size arrays"
 repository = "https://github.com/Manishearth/array-init/"
 documentation = "https://docs.rs/crate/array-init"

--- a/README.md
+++ b/README.md
@@ -21,19 +21,16 @@ which will be called once with the result copied over.
 # Examples:
 
 ```rust
-# #![allow(unused)]
-# extern crate array_init;
-
 // Initialize an array of length 50 containing
 // successive squares
 
-let arr: [u32; 50] = array_init::array_init(|i| (i*i) as u32);
+let arr: [usize; 50] = array_init::array_init(|i| i * i);
 
 // Initialize an array from an iterator
 // producing an array of [1,2,3,4] repeated
 
-let four = [1u32,2,3,4];
-let mut iter = four.iter().cloned().cycle();
+let four = [1,2,3,4];
+let mut iter = four.iter().copied().cycle();
 let arr: [u32; 50] = array_init::from_iter(iter).unwrap();
 
 // Closures can also mutate state. We guarantee that they will be called

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ mod tests {
                     }
                 })
             ;
-            let _ = result.map(|_array| unreachable!());
+            assert!(result.is_err());
         });
     }
 
@@ -345,7 +345,7 @@ mod tests {
         DropChecker::with(|drop_checker| {
             let iterator = (0 .. 3).map(|_| drop_checker.new_element());
             let result: Option<[_; 5]> = from_iter(iterator);
-            let _ = result.map(|_array| unreachable!());
+            assert!(result.is_none());
         });
     }
 
@@ -407,9 +407,7 @@ mod tests {
                         .map(|slot| usize::from(slot.get() as u8))
                         .sum()
                 ;
-                if leak_count != 0 {
-                    panic!("{} elements have leaked.", leak_count);
-                }
+                assert_eq!(leak_count, 0, "No elements leaked");
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-//! The `array-vec` crate allows you to initialize arrays
+//! The `array-init` crate allows you to initialize arrays
 //! with an initializer closure that will be called
 //! once for each element until the array is filled.
 //!
@@ -15,17 +15,17 @@
 //! ```rust
 //! # #![allow(unused)]
 //! # extern crate array_init;
-//!
-//! // Initialize an array of length 10 containing
+//! #
+//! // Initialize an array of length 50 containing
 //! // successive squares
 //!
-//! let arr: [u32; 50] = array_init::array_init(|i| (i*i) as u32);
+//! let arr: [u32; 50] = array_init::array_init(|i: usize| (i * i) as u32);
 //!
 //! // Initialize an array from an iterator
 //! // producing an array of [1,2,3,4] repeated
 //!
-//! let four = [1u32,2,3,4];
-//! let mut iter = four.iter().cloned().cycle();
+//! let four = [1,2,3,4];
+//! let mut iter = four.iter().copied().cycle();
 //! let arr: [u32; 50] = array_init::from_iter(iter).unwrap();
 //!
 //! // Closures can also mutate state. We guarantee that they will be called
@@ -41,122 +41,203 @@
 //! });
 //! ```
 
-use core::mem::{self, MaybeUninit};
-use core::ptr;
+use ::core::{
+    mem::{self,
+        MaybeUninit,
+    },
+    ops::Not,
+    ptr,
+    slice,
+};
 
-/// Trait for things which are actually arrays
+/// Trait for things which are actually arrays.
 ///
-/// Probably shouldn't implement this yourself,
-/// but you can
+/// Probably shouldn't implement this yourself, but you can.
+///
+/// # Safety
+///
+///   - if `Array : IsArray`, then it must be sound to transmute
+///     between `Array` and `[Array::Item; Array::len()]`
 pub unsafe trait IsArray {
     /// The stored `T`
     type Item;
 
+    /// The number of elements of the array
     fn len() -> usize;
 }
 
 #[inline]
-/// Initialize an array given an initializer expression
+/// Initialize an array given an initializer expression.
 ///
 /// The initializer is given the index of the element. It is allowed
 /// to mutate external state; we will always initialize the elements in order.
-///
-/// If your initializer panics, any elements that have been initialized
-/// will be leaked.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # #![allow(unused)]
 /// # extern crate array_init;
-///
-/// // Initialize an array of length 10 containing
+/// #
+/// // Initialize an array of length 50 containing
 /// // successive squares
+/// let arr: [usize; 50] = array_init::array_init(|i| i * i);
 ///
-/// let arr: [u32; 50] = array_init::array_init(|i| (i*i) as u32);
-///
-/// // Initialize an array from an iterator
-/// // producing an array of [1,2,3,4] repeated
-///
-/// let four = [1u32,2,3,4];
-/// let mut iter = four.iter().cloned().cycle();
-/// let arr: [u32; 50] = array_init::from_iter(iter).unwrap();
-///
+/// assert!(arr.iter().enumerate().all(|(i, &x)| x == i * i));
 /// ```
-///
-pub fn array_init<Array, F>(mut initializer: F) -> Array where Array: IsArray,
-                                                               F: FnMut(usize) -> Array::Item {
-    let mut ret: MaybeUninit<Array> = MaybeUninit::uninit();
-    // Poor Man's array-to-pointer decay from C O:-)
-    let mut elem = ret.as_mut_ptr() as usize as *mut Array::Item;
+pub fn array_init<Array, F> (
+    mut initializer: F,
+) -> Array
+where
+    Array : IsArray,
+    F : FnMut(usize) -> Array::Item,
+{
+    enum Unreachable {}
 
-    for i in 0..Array::len() {
-        let value = initializer(i);
-        unsafe {
-            ptr::write(elem, value);
-            // Using .add instead of offset to avoid having to check the offset in bytes not
-            // overflowing isize. We are guaranteed to be within the array, because we go one by
-            // one.
-            elem = elem.add(1);
+    try_array_init( // monomorphise into an unfallible version
+        move |i| -> Result<Array::Item, Unreachable> {
+            Ok(initializer(i))
         }
-    }
-
-    unsafe { ret.assume_init() }
+    ).unwrap_or_else( // zero-cost unwrap
+        |unreachable| match unreachable { /* ! */ }
+    )
 }
 
 #[inline]
 /// Initialize an array given an iterator
 ///
 /// We will iterate until the array is full or the iterator is exhausted. Returns
-/// None if the iterator is exhausted before we can fill the array.
+/// `None` if the iterator is exhausted before we can fill the array.
+///
+///   - Once the array is full, extra elements from the iterator (if any)
+///     won't be consumed.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # #![allow(unused)]
 /// # extern crate array_init;
-///
+/// #
 /// // Initialize an array from an iterator
 /// // producing an array of [1,2,3,4] repeated
 ///
-/// let four = [1u32,2,3,4];
-/// let mut iter = four.iter().cloned().cycle();
+/// let four = [1,2,3,4];
+/// let mut iter = four.iter().copied().cycle();
 /// let arr: [u32; 50] = array_init::from_iter(iter).unwrap();
 /// ```
-///
-pub fn from_iter<Array, I>(iter: I) -> Option<Array>
-    where I: IntoIterator<Item = Array::Item>,
-          Array: IsArray {
-    let mut ret: MaybeUninit<Array> = MaybeUninit::uninit();
-    // Poor Man's array-to-pointer decay from C O:-)
-    let mut elem = ret.as_mut_ptr() as usize as *mut Array::Item;
-
-    let mut count = 0;
-    for item in iter.into_iter().take(Array::len()) {
-        unsafe {
-            ptr::write(elem, item);
-            // Using .add instead of offset to avoid having to check the offset in bytes not
-            // overflowing isize. We are guaranteed to be within the array, because we go one by
-            // one.
-            elem = elem.add(1);
+pub fn from_iter<Array, Iterable> (
+    iterable: Iterable,
+) -> Option<Array>
+where
+    Iterable : IntoIterator<Item = Array::Item>,
+    Array : IsArray,
+{
+    try_array_init({
+        let mut iterator = iterable.into_iter();
+        move |_| {
+            iterator.next().ok_or(())
         }
-        count += 1;
+    }).ok()
+}
+
+#[inline]
+fn try_array_init<Array, Err, F> (
+    mut initializer: F,
+) -> Result<Array, Err>
+where
+    Array : IsArray,
+    F : FnMut(usize) -> Result<Array::Item, Err>,
+{
+    if mem::needs_drop::<Array::Item>().not() {
+        let mut array: MaybeUninit<Array> = MaybeUninit::uninit();
+        // pointer to array = *mut [T; N] <-> *mut T = pointer to first element
+        let base_ptr = array.as_mut_ptr() as *mut Array::Item;
+
+        //   - Using `ptr::add` instead of `offset` avoids having to check
+        //     that the offset in bytes does not overflow isize.
+        //
+        // # Safety
+        //
+        //   - `IsArray`'s contract guarantees that we are within the array:
+        //     `0 <= i < Array::len`
+        //
+        //       - For instance, `Array::len <= (isize::MAX as usize)`
+        unsafe {
+            for i in 0 .. Array::len() {
+                let value_i = initializer(i)?;
+                base_ptr.add(i).write(value_i);
+            }
+            return Ok(array.assume_init());
+        }
     }
 
-    // crucial for safety!
-    if count == Array::len() {
-        Some(unsafe { ret.assume_init() })
-    } else {
-        if mem::needs_drop::<Array::Item>() {
-            let mut elem = ret.as_mut_ptr() as usize as *mut Array::Item;
-            for _ in 0..count {
-                unsafe {
-                    ptr::drop_in_place(elem);
-                    elem = elem.add(1);
-                }
+    // else: `mem::needs_drop::<Array::Item>()`
+
+    /// # Safety
+    ///
+    ///   - `base_ptr[.. initialized_count]` must be a slice of init elements...
+    ///
+    ///   - ... that must be sound to `ptr::drop_in_place` if/when
+    ///     `UnsafeDropSliceGuard` is dropped: "symbolic ownership"
+    struct UnsafeDropSliceGuard<Item> {
+        base_ptr: *mut Item,
+        initialized_count: usize,
+    }
+
+    impl<Item> Drop for UnsafeDropSliceGuard<Item> {
+        fn drop (self: &'_ mut Self)
+        {
+            unsafe {
+                // # Safety
+                //
+                //   - the contract of the struct guarantees that this is sound
+                ptr::drop_in_place(
+                    slice::from_raw_parts_mut(
+                        self.base_ptr,
+                        self.initialized_count,
+                    )
+                );
             }
         }
-        None
+    }
+
+    //  1. If the `initializer(i)` call panics, `panic_guard` is dropped,
+    //     dropping `array[.. initialized_count]` => no memory leak!
+    //
+    //  2. Using `ptr::add` instead of `offset` avoids having to check
+    //     that the offset in bytes does not overflow isize.
+    //
+    // # Safety
+    //
+    //  1. By construction, array[.. initiliazed_count] only contains
+    //     init elements, thus there is no risk of dropping uninit data;
+    //
+    //  2. `IsArray`'s contract guarantees that we are within the array:
+    //     `0 <= i < Array::len`
+    //
+    //       - For instance, `Array::len <= (isize::MAX as usize)`
+    unsafe {
+        let mut array: MaybeUninit<Array> = MaybeUninit::uninit();
+        // pointer to array = *mut [T; N] <-> *mut T = pointer to first element
+        let base_ptr = array.as_mut_ptr() as *mut Array::Item;
+        let mut panic_guard = UnsafeDropSliceGuard {
+            base_ptr,
+            initialized_count: 0,
+        };
+
+        for i in 0 .. Array::len() {
+            // Invariant: `i` elements have already been initialized
+            panic_guard.initialized_count = i;
+            // If this panics or fails, `panic_guard` is dropped, thus
+            // dropping the elements in `base_ptr[.. i]`
+            let value_i = initializer(i)?;
+            // this cannot panic
+            panic_guard.base_ptr.add(i).write(value_i);
+        }
+        // From now on, the code can no longer `panic!`, let's take the
+        // symbolic ownership back
+        mem::forget(panic_guard);
+
+        Ok(array.assume_init())
     }
 }
 
@@ -224,8 +305,112 @@ mod tests {
     use super::*;
 
     #[test]
-    fn seq() {
+    fn seq ()
+    {
         let seq: [usize; 5] = array_init(|i| i);
         assert_eq!(&[0, 1, 2, 3, 4], &seq);
+    }
+
+    #[test]
+    fn array_from_iter ()
+    {
+        let array = [0, 1, 2, 3, 4];
+        let seq: [usize; 5] = from_iter(array.iter().copied()).unwrap();
+        assert_eq!(
+            array,
+            seq,
+        );
+    }
+
+    #[test]
+    fn array_init_no_drop ()
+    {
+        DropChecker::with(|drop_checker| {
+            let result: Result<[_; 5], ()> =
+                try_array_init(|i| {
+                    if i < 3 {
+                        Ok(drop_checker.new_element())
+                    } else {
+                        Err(())
+                    }
+                })
+            ;
+            let _ = result.map(|_array| unreachable!());
+        });
+    }
+
+    #[test]
+    fn from_iter_no_drop ()
+    {
+        DropChecker::with(|drop_checker| {
+            let iterator = (0 .. 3).map(|_| drop_checker.new_element());
+            let result: Option<[_; 5]> = from_iter(iterator);
+            let _ = result.map(|_array| unreachable!());
+        });
+    }
+
+    use self::drop_checker::DropChecker;
+    mod drop_checker {
+        use ::core::cell::Cell;
+
+        pub(in super)
+        struct DropChecker {
+            slots: [Cell<bool>; 512],
+            next_uninit_slot: Cell<usize>,
+        }
+
+        pub(in super)
+        struct Element<'drop_checker> {
+            slot: &'drop_checker Cell<bool>,
+        }
+
+        impl Drop for Element<'_> {
+            fn drop (self: &'_ mut Self)
+            {
+                assert!(self.slot.replace(false), "Double free!");
+            }
+        }
+
+        impl DropChecker {
+            pub(in super)
+            fn with (f: impl FnOnce(&Self))
+            {
+                let drop_checker = Self::new();
+                f(&drop_checker);
+                drop_checker.assert_no_leaks();
+            }
+
+            pub(in super)
+            fn new_element (self: &'_ Self) -> Element<'_>
+            {
+                let i = self.next_uninit_slot.get();
+                self.next_uninit_slot.set(i + 1);
+                self.slots[i].set(true);
+                Element {
+                    slot: &self.slots[i],
+                }
+            }
+
+            fn new () -> Self
+            {
+                Self {
+                    slots: crate::array_init(|_| Cell::new(false)),
+                    next_uninit_slot: Cell::new(0),
+                }
+            }
+
+            fn assert_no_leaks (self: Self)
+            {
+                let leak_count: usize =
+                    self.slots[.. self.next_uninit_slot.get()]
+                        .iter()
+                        .map(|slot| usize::from(slot.get() as u8))
+                        .sum()
+                ;
+                if leak_count != 0 {
+                    panic!("{} elements have leaked.", leak_count);
+                }
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@ use ::core::{
     mem::{self,
         MaybeUninit,
     },
-    ops::Not,
     ptr,
     slice,
 };
@@ -147,7 +146,7 @@ where
     Array : IsArray,
     F : FnMut(usize) -> Result<Array::Item, Err>,
 {
-    if mem::needs_drop::<Array::Item>().not() {
+    if !mem::needs_drop::<Array::Item>() {
         let mut array: MaybeUninit<Array> = MaybeUninit::uninit();
         // pointer to array = *mut [T; N] <-> *mut T = pointer to first element
         let mut ptr_i = array.as_mut_ptr() as *mut Array::Item;


### PR DESCRIPTION
 1. When the items have no drop glue, this PR does not change the logic of the code; but when there is, a counter is used to keep track of the number of initialized elements in order to drop them on `panic!()` or iterator exhaustion (both things are factored out thanks to a private `try_from_iter()` constructor), using a custom `Drop` guard.

      - (I guess `try_from_iter()` could be made public)

 1. Some minor changes, regarding the documentation (avoid `as` lossy casts; use the now stable `.copied()` iterator adapter) and usage of `edition = "2018"`.

 1. New tests have been added, checking against the "no memory leak" guarantee.

      - they pass `Miri`