### PR TITLE
Make the internal `try_array_init()` function public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ where
 }
 
 #[inline]
-fn try_array_init<Array, Err, F> (
+pub fn try_array_init<Array, Err, F> (
     mut initializer: F,
 ) -> Result<Array, Err>
 where


### PR DESCRIPTION
I guess it was an oversight from my previous PR, but the factored out `try_array_init()` function (for fallible initializers), is not `pub`lic; I think that could be changed 🙂