### PR TITLE
change from minimal const generics to proper const generics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(feature = "const-generics", feature(min_const_generics))]
+#![cfg_attr(feature = "const-generics", feature(const_generics))]
 
 //! The `array-init` crate allows you to initialize arrays
 //! with an initializer closure that will be called
@@ -303,7 +303,7 @@ impl_is_array! {
 #[cfg(feature = "const-generics")]
 unsafe impl<T, const N: usize> IsArray for [T; N] {
     type Item = T;
-    
+
     #[inline]
     fn len() -> usize {
         N


### PR DESCRIPTION
Hi there!

I was creating my own function having a very similar purpose to array-init. However, mine had to support const generics. Until I was looking through your source code and found out that on master your crate already supports const generics! Almost. The implementation seems to work but the feature name is `min_const_generics`. However, the crate doesn't compile with this feature 
![image](https://user-images.githubusercontent.com/22172241/95087655-430add00-0722-11eb-8c10-bca8244423eb.png)
Suggesting you need a full version of const generics, not the minimal version. 

I'm not sure how badly you want to keep `min_const_generics` or if you're fine with switching to `const_generics`, however currently your crate doesn't compile with the const_generics feature on. 
