### PR TITLE
Remove const-generic feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![cfg_attr(feature = "const-generics", feature(const_generics))]
 
 //! The `array-init` crate allows you to initialize arrays
 //! with an initializer closure that will be called


### PR DESCRIPTION
We don't need the `const-generics` rust feature flag anymore as beta has support now: https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html

![image](https://user-images.githubusercontent.com/1809198/109333055-416fbc00-785f-11eb-9602-4ed2253992f7.png)
Everything indeed seems to just work.