### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,12 +275,12 @@ where
         //       place before writing, going back N times in total, finishing
         //       at the start of the array.
         //
-        unsafe {
+        
             let mut array: MaybeUninit<[T; N]> = MaybeUninit::uninit();
             // pointer to array = *mut [T; N] <-> *mut T = pointer to first element
             let mut ptr_i = array.as_mut_ptr() as *mut T;
             if D < 0 {
-                ptr_i = ptr_i.add(N);
+                ptr_i = unsafe { ptr_i.add(N) };
             }
             let mut panic_guard = UnsafeDropSliceGuard {
                 base_ptr: ptr_i,
@@ -297,20 +297,20 @@ where
                 // this cannot panic
                 // the previously uninit value is overwritten without being read or dropped
                 if D < 0 {
-                    ptr_i = ptr_i.sub(1);
+                    ptr_i = unsafe { ptr_i.sub(1) };
                     panic_guard.base_ptr = ptr_i;
                 }
-                ptr_i.write(value_i);
+                unsafe { ptr_i.write(value_i) };
                 if D > 0 {
-                    ptr_i = ptr_i.add(1);
+                    ptr_i = unsafe { ptr_i.add(1) };
                 }
             }
             // From now on, the code can no longer `panic!`, let's take the
             // symbolic ownership back
             mem::forget(panic_guard);
 
-            Ok(array.assume_init())
-        }
+            Ok(unsafe { array.assume_init() })
+        
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions. However, I found that only 4 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the add()\sub()\write()\assume_init() function(these are unsafe functions)
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 