### PR TITLE
Add an MSRV policy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,12 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,10 +13,18 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust_version:
+          - stable
+          - 1.51  # MSRV (Minimum Supported Rust Version)
 
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{matrix.rust_version}}
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
-## v1.0.0
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## Unreleased
+### Added
+- Added `map_array_init` function ([#38](https://github.com/Manishearth/array-init/pull/38))
+
+## v2.0.1 (2022-06-24)
+### Added
+- Added `from_iter_reversed` function ([#30](https://github.com/Manishearth/array-init/issues/30))
+
+## v2.0.0 (2021-03-29)
+### Breaking
+- Removed `IsArray` trait (not necessary anymore with const generics)
+
+## v1.1.0 (yanked)
+### Breaking
+- Removed `const-generics` feature flag. The MSRV is now rust 1.51
+
+## v1.0.0 (2020-10-14)
 ### Added
   - Added a `try_array_init` function which initializes an array with a callable that may fail.
   - Added a `const-generics` feature which uses rust (unstable) `const-generics` feature to implement the initializer functions for all array sizes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ documentation = "https://docs.rs/crate/array-init"
 keywords = ["abstraction", "initialization", "no_std"]
 categories = ["data-structures", "no-std"]
 exclude = [".travis.yml"]
+
+[package.metadata]
+# to be replaced by `package.rust-version` once we increase the msrv beyond 1.56
+msrv = "1.51"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ let fibonacci: [u64; 50] = array_init::array_init(|_| {
 });
 ```
 
+## Minimum Supported Rust Version (MSRV)
+
+`array-init` will only increase the MSRV on a new major
+or minor release, but not for patch releases.
+Any changes of the MSRV will be announced in the changelog.
+When increasing the MSRV, the new Rust version must have been
+released at least six months ago. The current MSRV is 1.51.0.
+MSRV changes can be expected to happen conservatively.
+
 ## Licensing
 
 Licensed under either of Apache License, Version 2.0 or MIT license at your option.


### PR DESCRIPTION
Changes seperated by commits:
- Update github actions to more recent versions (node 12 is [being deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/))
- Add an MSRV policy as discussed in #39 and test MSRV in CI. We can't set `rust-version` in the Cargo.toml since that requires Rust 1.56, so instead I used the metadata field which is read by [cargo msrv](https://crates.io/crates/cargo-msrv)
- Updated the Changelog based on the commit history of this project since v1.0